### PR TITLE
Initial Draft of a validator only node setup

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -175,6 +175,8 @@ type TxPoolConfig struct {
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
+
+	FastLanePeer string // Peer to prioritize with Fastlane.
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -192,6 +194,8 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	GlobalQueue:  1024,
 
 	Lifetime: 3 * time.Hour,
+
+	FastLanePeer: "", // Default: No prioritized peer.
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -176,7 +176,7 @@ type TxPoolConfig struct {
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
 
-	FastLanePeer string // Peer to prioritize with Fastlane.
+	FastLanePeer string // Peer to prioritize with FastLane.
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -266,7 +266,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		EthAPI:             ethAPI,
 		PeerRequiredBlocks: config.PeerRequiredBlocks,
 		checker:            checker,
-		fastLanePeer: 		config.TxPool.FastLanePeer,
+		fastLanePeer:       config.TxPool.FastLanePeer,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -266,6 +266,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		EthAPI:             ethAPI,
 		PeerRequiredBlocks: config.PeerRequiredBlocks,
 		checker:            checker,
+		fastLanePeer: 		config.TxPool.FastLanePeer,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -179,14 +179,14 @@ type TxFetcher struct {
 	clock mclock.Clock  // Time wrapper to simulate in tests
 	rand  *mrand.Rand   // Randomizer to use in tests instead of map range loops (soft-random)
 
-	// The peer string of a fastlane node.
+	// The peer string of a FastLane node.
 	fastLanePeer string
 }
 
 // NewTxFetcher creates a transaction fetcher to retrieve transaction
 // based on hash announcements.
-func NewTxFetcher(hasTx func(common.Hash) bool, addTxs func([]*types.Transaction) []error, fetchTxs func(string, []common.Hash) error, fastlanePeer string) *TxFetcher {
-	return NewTxFetcherForTests(hasTx, addTxs, fetchTxs, mclock.System{}, nil, fastlanePeer)
+func NewTxFetcher(hasTx func(common.Hash) bool, addTxs func([]*types.Transaction) []error, fetchTxs func(string, []common.Hash) error, fastLanePeer string) *TxFetcher {
+	return NewTxFetcherForTests(hasTx, addTxs, fetchTxs, mclock.System{}, nil, fastLanePeer)
 }
 
 // NewTxFetcherForTests is a testing method to mock out the realtime clock with
@@ -196,7 +196,7 @@ func NewTxFetcherForTests(
 	clock mclock.Clock, rand *mrand.Rand, fastLanePeer string) *TxFetcher {
 
 	if fastLanePeer == "" {
-		log.Warn("Warning: FastLane peer is not set. ")
+		log.Warn("[FastLane] FastLane peer is not set.")
 	}
 
 	return &TxFetcher{
@@ -282,12 +282,12 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 
 	// Only execute FastLane logic if there is a FastLane Peer set.
 	if f.fastLanePeer != "" {
-		// Delay non-FastLane peer txs for up to 500ms.
+		// Delay non-FastLane peer txs by nonFastLaneTxDelay
 		isFastLanePeer := peer == f.fastLanePeer
 		log.Debug("[FastLane] Received transactions from peer %s (isFastLanePeer = %t)", peer, isFastLanePeer)
 		if isFastLanePeer {
 			log.Debug("[FastLane] Delaying tx addition to mempool for peer %s", peer)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(nonFastLaneTxDelay)
 			log.Debug("[FastLane] Delaying complete for peer %s", peer)
 		} else {
 			log.Debug("[FastLane] Will not delay addition of txs to mempool.")

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -93,6 +93,8 @@ type handlerConfig struct {
 
 	PeerRequiredBlocks map[uint64]common.Hash // Hard coded map of required block hashes for sync challenges
 	checker            ethereum.ChainValidator
+
+	fastLanePeer string
 }
 
 type handler struct {
@@ -307,7 +309,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 		return p.RequestTxs(hashes)
 	}
-	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, h.txpool.AddRemotes, fetchTx)
+	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, h.txpool.AddRemotes, fetchTx, config.fastLanePeer)
 	h.chainSync = newChainSyncer(h)
 	return h, nil
 }


### PR DESCRIPTION
Initial draft of PFL without a sentry node. I have *not* tested this yet, as I'm waiting for a Mumbai node to synchronize. 

Implementation:
1. Add a new field (`FastLanePeer` to the `txpool` section of `config.toml`). Set this field to a string to delay txs from non-matching peers by 500ms, or set to empty string to turn tx delays off. Default: ""
2. Plumb new config field into `tx_fetcher.go`
3. When txs are enqueued, check if sending peer is the `FastLanePeer`, if one is set. If so, sleep for 500ms. 

Remaining work:
- [ ] Test
- [ ] Add docs and examples
